### PR TITLE
Make CodeResources files respect rules better / add sha256 hashes

### DIFF
--- a/isign/code_resources_template.xml
+++ b/isign/code_resources_template.xml
@@ -23,6 +23,11 @@
 			<key>weight</key>
 			<real>1100</real>
 		</dict>
+		<key>^Base\.lproj/</key>
+		<dict>
+			<key>weight</key>
+			<real>1010</real>
+		</dict>
 		<key>^version.plist$</key>
 		<true/>
 	</dict>
@@ -67,6 +72,11 @@
 			<true/>
 			<key>weight</key>
 			<real>1100</real>
+		</dict>
+		<key>^Base\.lproj/</key>
+		<dict>
+			<key>weight</key>
+			<real>1010</real>
 		</dict>
 		<key>^Info\.plist$</key>
 		<dict>


### PR DESCRIPTION
The 'files' dict was using the wrong ruleset, which wasn't properly omitting some files from being included.

Additionally, 'files2' was missing sha256 hashes for files, so added that.