### PR TITLE
Allow missing/invalid CFBundleSupportedPlatforms key

### DIFF
--- a/isign/bundle.py
+++ b/isign/bundle.py
@@ -48,7 +48,8 @@ class Bundle(object):
         self.info = biplist.readPlist(self.info_path)
         self.orig_info = None
         if not is_info_plist_native(self.info):
-            raise NotMatched("not a native iOS bundle")
+            # while we should probably not allow this *or* add it ourselves, it appears to work without it
+            log.debug(u"Missing/invalid CFBundleSupportedPlatforms value in {}".format(self.info_path))
         # will be added later
         self.seal_path = None
 


### PR DESCRIPTION
One framework was missing the value entirely, despite the app otherwise successfully installing and running without it. Because of how *we* use isign this isn't a problem, though other uses of `is_info_plist_native` (e.g. Archive classes via `precheck`) may care more about it being missing or invalid.