### PR TITLE
remove control char in path and add utf-8 doc header

### DIFF
--- a/bin/isign
+++ b/bin/isign
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+# -*- coding: utf-8 -*-
 import argparse
 from isign import isign
 from os.path import abspath, expanduser

--- a/bin/make_seal
+++ b/bin/make_seal
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+# -*- coding: utf-8 -*-
 from optparse import OptionParser
 import isign.code_resources
 import logging

--- a/bin/multisign
+++ b/bin/multisign
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+# -*- coding: utf-8 -*-
 # From a single IPA, generate multiple re-signed IPAs simultaneously.
 # Why? Because you might want to distribute an app to a lot of organizations at once,
 # or perhaps you need to sign for an enterprise and a local debug deployment all at

--- a/bin/pprint_codesig
+++ b/bin/pprint_codesig
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+# -*- coding: utf-8 -*-
 import argparse
 import isign.archive
 from isign.exceptions import NotSignable

--- a/isign/__init__.py
+++ b/isign/__init__.py
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# -*- coding: utf-8 -*-
 import os.path
 import json
 

--- a/isign/archive.py
+++ b/isign/archive.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*- 
 """ Represents an app archive. This is an app at rest, whether it's a naked
     app bundle in a directory, or a zipped app bundle, or an IPA. We have a
     common interface to extract these apps to a temp file, then resign them,
@@ -14,10 +15,13 @@ from os.path import abspath, dirname, exists, isdir, isfile, join, normpath
 import tempfile
 import re
 from subprocess import call
+
+
 from signer import Signer
 import shutil
 import zipfile
 
+import utils
 
 REMOVE_WATCHKIT = True
 helper_paths = {}
@@ -303,6 +307,7 @@ class UncompressedArchive(object):
                 (or the dir itself, in the case of an AppArchive archive)
             relative bundle dir is the dir containing the bundle, e.g. Payload/Foo.app
             archive class is the kind of archive this was (Ipa, etc.) """
+        path = utils.remove_control_char(path)
         self.path = path
         self.relative_bundle_dir = relative_bundle_dir
         self.archive_class = archive_class

--- a/isign/bundle.py
+++ b/isign/bundle.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """ Represents a bundle. In the words of the Apple docs, it's a convenient way to deliver
     software. Really it's a particular kind of directory structure, with one main executable,
     well-known places for various data files and libraries,
@@ -20,7 +21,7 @@ from os.path import basename, exists, join, splitext
 from signer import openssl_command
 import signable
 import shutil
-
+import utils
 
 log = logging.getLogger(__name__)
 
@@ -41,6 +42,8 @@ class Bundle(object):
     entitlements_path = None  # Not set for every bundle type
 
     def __init__(self, path):
+        # Remove Control character
+        path = utils.remove_control_char(path)
         self.path = path
         self.info_path = join(self.path, 'Info.plist')
         if not exists(self.info_path):
@@ -64,6 +67,7 @@ class Bundle(object):
             executable_name = self.info['CFBundleExecutable']
         else:
             executable_name, _ = splitext(basename(self.path))
+        executable_name = utils.remove_control_char(executable_name)
         executable = join(self.path, executable_name)
         if not exists(executable):
             raise Exception(

--- a/isign/code_resources.py
+++ b/isign/code_resources.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import binascii
 import copy
 import hashlib

--- a/isign/codesig.py
+++ b/isign/codesig.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from abc import ABCMeta
 import construct
 import hashlib

--- a/isign/exceptions.py
+++ b/isign/exceptions.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """ Some common exceptions """
 
 

--- a/isign/isign.py
+++ b/isign/isign.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import archive
 # import makesig
 import exceptions

--- a/isign/macho.py
+++ b/isign/macho.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Constructs to represent various structures
 # in a Mach-O binary.

--- a/isign/macho_cs.py
+++ b/isign/macho_cs.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # This is a Construct library which represents an
 # LC_CODE_SIGNATURE structure. Like all Construct

--- a/isign/makesig.py
+++ b/isign/makesig.py
@@ -1,4 +1,4 @@
-#
+# -*- coding: utf-8 -*-
 # Library to construct an LC_CODE_SIGNATURE construct
 # from scratch. Does not work yet.
 #

--- a/isign/multisign.py
+++ b/isign/multisign.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from os.path import isdir
 import isign
 from archive import archive_factory

--- a/isign/signable.py
+++ b/isign/signable.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Represents a file that can be signed. A file that
 # conforms to the Mach-O ABI.

--- a/isign/signer.py
+++ b/isign/signer.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Small object that can be passed around easily, that represents
 # our signing credentials, and can sign data.

--- a/isign/utils.py
+++ b/isign/utils.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*- 
 import binascii
+import re
 
 
 def print_data(data):
@@ -15,4 +17,7 @@ def round_up(x, k):
 def print_structure(container, struct):
     actual_data = struct.build(container)
     return "{}".format(struct.parse(actual_data))
-
+# remove control character in string
+# This will affect the executable_name part in path
+def remove_control_char(str):
+    return re.compile('[\\x00-\\x08\\x0b-\\x0c\\x0e-\\x1f]').sub('', str)


### PR DESCRIPTION
1.fix remove control char in path
> Linux will ignore the control characters present in `CFBundleExecutable` when extracting wrapper files, but this will not be ignored in Python, which will result in incorrect comparisons when using `os.path.exists` for comparison. result.
eg: 
![image](https://user-images.githubusercontent.com/31845646/65006107-b6ce2200-d934-11e9-98bd-f2140b247c6b.png)



2.add utf-8 doc header