### PR TITLE
Supplementary method call parameter

### DIFF
--- a/isign/bundle.py
+++ b/isign/bundle.py
@@ -156,7 +156,7 @@ class Bundle(object):
                     continue
                 plist = biplist.readPlist(plist_path)
                 appex_exec_path = join(appex_path, plist['CFBundleExecutable'])
-                appex = signable.Appex(self, appex_exec_path)
+                appex = signable.Appex(self, appex_exec_path, signer)
                 appex.sign(self, signer)
 
         # then create the seal


### PR DESCRIPTION
Supplementary method calls parameters to solve the following problem
```log
Removing WatchKit bundle /tmp/isign-nHoQFS/Payload/QQMusic.app/Watch
Traceback (most recent call last):
  File "/usr/local/bin/isign", line 8, in <module>
    __import__('pkg_resources').run_script('isign==1.6.15.1567763317.dev63+root', 'isign')
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 748, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 1517, in run_script
    exec(code, namespace, namespace)
  File "/usr/local/lib/python2.7/dist-packages/isign-1.6.15.1567763317.dev63+root-py2.7.egg/EGG-INFO/scripts/isign", line 199, in <module>
    isign.resign(app_path, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/isign-1.6.15.1567763317.dev63+root-py2.7.egg/isign/isign.py", line 80, in resign
    alternate_entitlements_path)
  File "/usr/local/lib/python2.7/dist-packages/isign-1.6.15.1567763317.dev63+root-py2.7.egg/isign/archive.py", line 405, in resign
    ua.bundle.resign(signer, provisioning_profile, alternate_entitlements_path)
  File "/usr/local/lib/python2.7/dist-packages/isign-1.6.15.1567763317.dev63+root-py2.7.egg/isign/bundle.py", line 269, in resign
    super(App, self).resign(signer)
  File "/usr/local/lib/python2.7/dist-packages/isign-1.6.15.1567763317.dev63+root-py2.7.egg/isign/bundle.py", line 186, in resign
    self.sign(signer)
  File "/usr/local/lib/python2.7/dist-packages/isign-1.6.15.1567763317.dev63+root-py2.7.egg/isign/bundle.py", line 171, in sign
    appex = signable.Appex(self, appex_exec_path)
TypeError: __init__() takes exactly 4 arguments (3 given)
```